### PR TITLE
TOURLY-3 - Added /me endpoint

### DIFF
--- a/src/main/kotlin/com/tourly/core/api/controller/UserController.kt
+++ b/src/main/kotlin/com/tourly/core/api/controller/UserController.kt
@@ -1,0 +1,35 @@
+package com.tourly.core.api.controller
+
+import com.tourly.core.api.dto.User
+import com.tourly.core.security.CustomUserDetails
+import org.springframework.http.ResponseEntity
+import org.springframework.security.core.annotation.AuthenticationPrincipal
+import org.springframework.web.bind.annotation.GetMapping
+import org.springframework.web.bind.annotation.RequestMapping
+import org.springframework.web.bind.annotation.RestController
+
+@RestController
+@RequestMapping("/api/users")
+class UserController {
+
+    @GetMapping("/me")
+    fun me(@AuthenticationPrincipal userDetails: CustomUserDetails): ResponseEntity<*> {
+        try {
+            val roleName = userDetails.getRole()
+            println("DEBUG: Fetching profile for user: ${userDetails.username}, role: $roleName")
+            
+            val user = User(
+                id = userDetails.getUserId(),
+                email = userDetails.username,
+                firstName = userDetails.getFirstName(),
+                lastName = userDetails.getLastName(),
+                role = com.tourly.core.data.enumeration.UserRole.valueOf(roleName)
+            )
+            return ResponseEntity.ok(user)
+        } catch (e: Exception) {
+            e.printStackTrace() // Print stack trace to backend console
+            println("DEBUG: Error in /me endpoint: ${e.message}")
+            return ResponseEntity.status(500).body("Error fetching profile: ${e.message}")
+        }
+    }
+}


### PR DESCRIPTION
## Summary
This PR adds an endpoint for retrieving the authenticated user’s profile information from the security context.

## Linked Issues
- #6 

## Changes Overview

### UserController
- Added `GET /api/users/me` endpoint to return the currently authenticated user.
- Extracts user information from `CustomUserDetails`.
- Maps security principal data to `User` DTO.

### Security Integration
- Utilizes `@AuthenticationPrincipal` to access authenticated user details.
- Ensures role mapping via `UserRole` enum.
