### PR TITLE
TOURLY-4 - Email Uniqueness Validation on Profile Update

### DIFF
--- a/src/main/kotlin/com/tourly/core/exception/ErrorCode.kt
+++ b/src/main/kotlin/com/tourly/core/exception/ErrorCode.kt
@@ -12,5 +12,6 @@ enum class ErrorCode(
     RESOURCE_NOT_FOUND("TY-2", "Resource Not Found", HttpStatus.NOT_FOUND),
     BAD_REQUEST("TY-3", "Bad Request", HttpStatus.BAD_REQUEST),
     UNAUTHORIZED("TY-4", "Unauthorized", HttpStatus.UNAUTHORIZED),
-    FORBIDDEN("TY-5", "Forbidden", HttpStatus.FORBIDDEN)
+    FORBIDDEN("TY-5", "Forbidden", HttpStatus.FORBIDDEN),
+    CONFLICT("TY-6", "Conflict", HttpStatus.CONFLICT)
 }

--- a/src/main/kotlin/com/tourly/core/exception/GlobalExceptionHandler.kt
+++ b/src/main/kotlin/com/tourly/core/exception/GlobalExceptionHandler.kt
@@ -1,6 +1,7 @@
 package com.tourly.core.exception
 
 import org.springframework.http.ResponseEntity
+import org.springframework.security.authentication.BadCredentialsException
 import org.springframework.web.bind.MethodArgumentNotValidException
 import org.springframework.web.bind.annotation.ExceptionHandler
 import org.springframework.web.bind.annotation.RestControllerAdvice
@@ -33,8 +34,8 @@ class GlobalExceptionHandler {
         return ResponseEntity.status(errorCode.httpStatus).body(response)
     }
 
-    @ExceptionHandler(org.springframework.security.authentication.BadCredentialsException::class)
-    fun handleBadCredentials(ex: org.springframework.security.authentication.BadCredentialsException): ResponseEntity<ErrorResponse> {
+    @ExceptionHandler(BadCredentialsException::class)
+    fun handleBadCredentials(ex: BadCredentialsException): ResponseEntity<ErrorResponse> {
         val errorCode = ErrorCode.UNAUTHORIZED
         val response = ErrorResponse(
             code = errorCode.code,

--- a/src/main/kotlin/com/tourly/core/service/UserService.kt
+++ b/src/main/kotlin/com/tourly/core/service/UserService.kt
@@ -29,9 +29,18 @@ class UserService(
     fun updateProfile(userId: Long, request: UpdateProfileRequestDto): UserDto {
         val user = findUser(userId)
 
+        if (request.email != user.email) {
+            if (userRepository.existsByEmail(request.email)) {
+                throw APIException(
+                    errorCode = ErrorCode.CONFLICT,
+                    description = "Email already in use: ${request.email}"
+                )
+            }
+            user.email = request.email
+        }
+        
         user.firstName = request.firstName
         user.lastName = request.lastName
-        user.email = request.email
 
         if (!request.password.isNullOrBlank()) {
             user.password = passwordEncoder.encode(request.password).toString()


### PR DESCRIPTION
## Summary
Adds email uniqueness validation to the profile update endpoint, preventing users from changing their email to one already in use. Introduces a new `CONFLICT` (409) error code for duplicate email scenarios.

## Linked Issues
- Part of #10 

---

## Changes

### UserService
* Added email uniqueness check before updating email
* Only validates and updates email when it changes from current value
* Throws `APIException` with `CONFLICT` error code if email already exists

### ErrorCode Enum
* Added `CONFLICT` error code (`TY-6`, HTTP 409)

### GlobalExceptionHandler
* Code cleanup: Added import for `BadCredentialsException`

---

## API Changes

**Endpoint**: `PUT /api/users/me`

**New Error Response**:
```json
{
  "code": "TY-6",
  "message": "Conflict",
  "description": "Email already in use: user@example.com",
  "timestamp": "2026-01-08T10:30:00Z"
}
```

**Updated Status Codes**:
- `200 OK` - Profile updated successfully
- `400 BAD REQUEST` - Invalid input
- `401 UNAUTHORIZED` - Invalid/missing token
- `409 CONFLICT` - **NEW** Email already in use
- `500 INTERNAL SERVER ERROR` - Server error
